### PR TITLE
Merge use of AudioStream sample rate

### DIFF
--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -34,7 +34,6 @@
 #ifndef __ASSEMBLER__
 #include <stdio.h>  // for NULL
 #include <string.h> // for memcpy
-
 #endif
 
 // AUDIO_BLOCK_SAMPLES determines how many samples the audio library processes
@@ -60,23 +59,23 @@
 
 #define AUDIO_SAMPLE_RATE AUDIO_SAMPLE_RATE_EXACT
 
-#define noAUDIO_DEBUG_CLASS // disable this class by default
-
-#ifndef __ASSEMBLER__
-class AudioStream;
-class AudioConnection;
-#if defined(AUDIO_DEBUG_CLASS)
-class AudioDebug;  // for testing only, never for public release
-#endif // defined(AUDIO_DEBUG_CLASS)
-
+#if !defined(__ASSEMBLER__)
 typedef struct audio_block_struct {
 	uint8_t  ref_count;
 	uint8_t  reserved1;
 	uint16_t memory_pool_index;
 	int16_t  data[AUDIO_BLOCK_SAMPLES];
 } audio_block_t;
+#endif // !defined(__ASSEMBLER__)
 
+#define noAUDIO_DEBUG_CLASS // disable this class by default
 
+#if defined(__cplusplus)
+class AudioStream;
+class AudioConnection;
+#if defined(AUDIO_DEBUG_CLASS)
+class AudioDebug;  // for testing only, never for public release
+#endif // defined(AUDIO_DEBUG_CLASS)
 
 class AudioConnection
 {
@@ -212,5 +211,5 @@ class AudioDebug
 };
 #endif // defined(AUDIO_DEBUG_CLASS)
 
-#endif // __ASSEMBLER__
+#endif // defined(__cplusplus)
 #endif // AudioStream_h

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -37,6 +37,7 @@
 #include "imxrt.h"
 #include "avr_functions.h"
 #include "avr/pgmspace.h"
+#include "AudioStream.h"
 
 // At very slow CPU speeds, the OCRAM just isn't fast enough for
 // USB to work reliably.  But the precious/limited DTCM is.  So
@@ -69,8 +70,9 @@
 //   USB Device
 // **************************************************************
 
-#define LSB(n) ((n) & 255)
-#define MSB(n) (((n) >> 8) & 255)
+#define LSB(n) ((int)(n) & 255)
+#define MSB(n) (((int)(n) >> 8) & 255)
+#define HSB(n) (((int)(n) >> 16) & 255)
 
 #ifdef CDC_IAD_DESCRIPTOR
 #ifndef DEVICE_CLASS

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -1525,7 +1525,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
 	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	AUDIO_SAMPLE_FREQ(44100),		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -1584,7 +1584,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
 	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	AUDIO_SAMPLE_FREQ(44100),		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -2539,7 +2539,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -2598,7 +2598,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -763,11 +763,10 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_INTERFACE	1	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     3
   #define AUDIO_CHANNELS        8 // Must be a multiple of 2
-  #define AUDIO_FREQUENCY       44100
-  #define AUDIO_BIT_DEPTH       16
-  #define AUDIO_SAMPLE_BYTES    AUDIO_BIT_DEPTH / 8
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
   #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
-  // #define AUDIO_TX_SIZE         180
   #define AUDIO_RX_ENDPOINT     3
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	4
@@ -806,9 +805,13 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MIDI_RX_SIZE_480      512
   #define AUDIO_INTERFACE	3	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     5
-  #define AUDIO_TX_SIZE         180
+  #define AUDIO_CHANNELS        8 // Must be a multiple of 2
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
+  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
-  #define AUDIO_RX_SIZE         180
+  #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
@@ -848,9 +851,13 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MIDI_RX_SIZE_480      512
   #define AUDIO_INTERFACE	3	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     5
-  #define AUDIO_TX_SIZE         180
+  #define AUDIO_CHANNELS        8 // Must be a multiple of 2
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
+  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
-  #define AUDIO_RX_SIZE         180
+  #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
@@ -930,9 +937,13 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define KEYMEDIA_INTERVAL     4
   #define AUDIO_INTERFACE	9	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     13
-  #define AUDIO_TX_SIZE         180
+  #define AUDIO_CHANNELS        8 // Must be a multiple of 2
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
+  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     13
-  #define AUDIO_RX_SIZE         180
+  #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	14
   #define MULTITOUCH_INTERFACE  12	// Touchscreen
   #define MULTITOUCH_ENDPOINT   15


### PR DESCRIPTION
Merge use of AudioStream sample rate in the USB code with the implementation of multi-channel USB output and additional audio objects